### PR TITLE
Update runtimeClass apiVersion to node.k8s.io/v1

### DIFF
--- a/manifests/manifest.yaml
+++ b/manifests/manifest.yaml
@@ -37,7 +37,7 @@ spec:
             path: /etc/k0s/containerd.d/
             type: Directory
 ---
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: gvisor


### PR DESCRIPTION
The apiVersion for the runtimeClass in the manifest appears to be incorrect -- updating here.